### PR TITLE
Fix broken `git-name` param during home-manager template init

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,7 @@ echo "\n# Setting up home-manager & direnv"
 nix --accept-flake-config run github:juspay/omnix -- \
   init github:juspay/nixos-unified-template#home -o ~/nixconfig \
   --non-interactive \
-  --params '{"username":"'$(id -un)'", "git-name":"'$(id -F)'", "git-email":"'$(id -un)'@juspay.in"}'
+  --params '{"username":"'$(id -un)'", "git-name":"$(id -F)", "git-email":"'$(id -un)'@juspay.in"}'
 
 cd ~/nixconfig && nix run
 


### PR DESCRIPTION
Breaks when `id -F` has a space in the name. See:

![image](https://github.com/user-attachments/assets/06430030-05dd-41aa-afe7-019d1d8d9c3c)

The PR removes the single-quotes encompassing the output of `id -F` to prevent the shell from treating everything after the space as next argument.