### PR TITLE
home-manager: Use `id -un` for `git-name` param

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,7 @@ echo "\n# Setting up home-manager & direnv"
 nix --accept-flake-config run github:juspay/omnix -- \
   init github:juspay/nixos-unified-template#home -o ~/nixconfig \
   --non-interactive \
-  --params '{"username":"'$(id -un)'", "git-name":"'$(id -F)'", "git-email":"'$(id -un)'@juspay.in"}'
+  --params '{"username":"'$(id -un)'", "git-name":"'$(id -un)'", "git-email":"'$(id -un)'@juspay.in"}'
 
 cd ~/nixconfig && nix run
 

--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,7 @@ echo "\n# Setting up home-manager & direnv"
 nix --accept-flake-config run github:juspay/omnix -- \
   init github:juspay/nixos-unified-template#home -o ~/nixconfig \
   --non-interactive \
-  --params '{"username":"'$(id -un)'", "git-name":"$(id -F)", "git-email":"'$(id -un)'@juspay.in"}'
+  --params '{"username":"'$(id -un)'", "git-name":"'$(id -F)'", "git-email":"'$(id -un)'@juspay.in"}'
 
 cd ~/nixconfig && nix run
 


### PR DESCRIPTION
`id -F` breaks see https://github.com/juspay/nixone/pull/10#issue-2800251704

and the linked PR doesn't fix the problem as claimed, https://github.com/juspay/nixone/pull/10#issuecomment-2603255229. 

Hence, we avoid using `id -F` (also it is only macOS specific) and switch to `id -un`.