### PR TITLE
Add `/health` to run just health check

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -15,11 +15,11 @@ jobs:
       - name: Create GitHub Pages content
         run: |
           mkdir public
-          cp setup.sh public/
           echo '<html><body><pre>' > public/index.html
           echo "Please see https://github.com/juspay/nixone" >> public/index.html
           echo '</pre></body></html>' >> public/index.html
           cp setup.sh public/setup
+          cp health.sh public/health
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@ One-click setup of all things Nix for Juspay'ers. We provide an one-line CLI tha
 On a macOS machine that does not already have Nix installed run the following after getting "Temp admin access",
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf -L \
-  https://juspay.github.io/nixone/setup | sh -s
+curl --proto '=https' --tlsv1.2 -sSf -L https://juspay.github.io/nixone/setup | sh -s
 ```
 
 >[!NOTE]
 > You may still run this command if you installed Nix already using Determinate Systes nix-installer. The script will then setup `nix-dev-home` for you (see below).
+
+## Running health check only
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf -L https://juspay.github.io/nixone/health | sh -s
+```
 
 ## What it does
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,1 @@
+{ inputs = {}; outputs = _: {}; }

--- a/health.sh
+++ b/health.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eux
+
+nix --accept-flake-config run github:juspay/omnix health github:juspay/nixone
+

--- a/om.yaml
+++ b/om.yaml
@@ -1,0 +1,9 @@
+health:
+  default:
+    nix-version:
+      supported: ">=2.16.0"
+    direnv:
+      required: true
+    trusted-users:
+      enable: true
+


### PR DESCRIPTION
`om health` no longer shows the trusted-users check. Context: https://github.com/juspay/omnix/pull/419

So let's create an exception here for use in relevant projects until we figure out a better cache use workflow.