### PR TITLE
feat(flag -p): Generalizes for non juspay users

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,31 @@
 #!/bin/sh
 set -eu
 
+args=$(getopt -o 'p' -- "$@")
+eval set -- "$args"
+
+gitEmail="$(id -un)@juspay.in"
+
+# Process options
+while true; do
+  case "$1" in
+  -p)
+    shift # Move to the next argument
+    printf "Enter your email (default: %s): " "$gitEmail"
+    read -r email </dev/tty # Redirect input explicitly from terminal
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *)
+    echo "Invalid option"
+    exit 1
+    ;;
+  esac
+done
+gitEmail="${email:-$gitEmail}" # Use email if provided, else default to username@juspay.in
+
 # Check if nix is already installed
 if ! which nix > /dev/null; then
   # Install Nix
@@ -46,7 +71,7 @@ if echo "$health_out" | _jq -e '.checks.shell.result != "Green"' > /dev/null; th
   nix --accept-flake-config run github:juspay/omnix -- \
     init github:juspay/nixos-unified-template#home -o ~/.config/home-manager \
     --non-interactive \
-    --params '{"username":"'$(id -un)'", "git-name":"'$(id -un)'", "git-email":"'$(id -un)'@juspay.in"}'
+    --params '{"username":"'$(id -un)'", "git-name":"'$(id -un)'", "git-email":"'${gitEmail}'"}'
 
   cd ~/.config/home-manager && nix run
 


### PR DESCRIPTION
This introduces a flag `-p` to get `git-mail` from user input. addresses #15 

This is a draft as the issue can also be resolved if the provided system somehow exposes that they from organization then implementing that check will be a better option. 

but for now the soln this pr gives ⤵️ 

adding a prompt option in script that is triggered by a flag
e.g 
```
curl --proto '=https' --tlsv1.2 -sSf -L https://juspay.github.io/nixone/setup | sh -s -- -p
```

now the script execution should prompt the user to input `git-email` manually and if the user press `enter` without inputting anything default value with `$(id -un)@juspay.in` should be taken.