### PR TITLE
setup: Add `work.nix` from the template

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ if echo "$health_out" | _jq -e '.checks.shell.result != "Green"' > /dev/null; th
   nix --accept-flake-config run github:juspay/omnix -- \
     init github:juspay/nixos-unified-template#home -o ~/.config/home-manager \
     --non-interactive \
-    --params '{"username":"'$(id -un)'", "git-name":"'$(id -un)'", "git-email":"'$(id -un)'@juspay.in"}'
+    --params '{"username":"'$(id -un)'", "git-name":"'$(id -un)'", "git-email":"'$(id -un)'@juspay.in", "work": true}'
 
   cd ~/.config/home-manager && nix run
 


### PR DESCRIPTION
This contains fixes required for juspay org macs.
Resolves: #34

In favour of https://github.com/juspay/nixos-unified-template/pull/183 

**only merge once https://github.com/juspay/nixos-unified-template/pull/183 is merged**