### PR TITLE
setup: Downgrade nix-installer to 2.33.3

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@ done
 # Check if nix is already installed
 if ! which nix > /dev/null; then
   # Install Nix
-  curl --proto '=https' --tlsv1.2 -sSf -L https://artifacts.nixos.org/experimental-installer | \
+  curl --proto '=https' --tlsv1.2 -sSf -L https://artifacts.nixos.org/nix-installer/tag/2.33.3/nix-installer.sh | \
     sh -s -- install --no-confirm --extra-conf "trusted-users = $(whoami)"
 
   # Resolves https://github.com/juspay/nixone/issues/19


### PR DESCRIPTION
nix 2.34 was failing to authenticate to attic binary cache with HTTP status 401. The root cause is unknown as of writing this commit.

Also: no longer experimental https://github.com/NixOS/nix-installer
