### PR TITLE
install-nix: 2.33.3 -> 2.34.5

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -16,7 +16,7 @@ if [ -d "/nix" ]; then
 fi
 
 curl --proto '=https' --tlsv1.2 -sSf -L \
-  https://artifacts.nixos.org/nix-installer/tag/2.33.3/nix-installer.sh | \
+  https://artifacts.nixos.org/nix-installer/tag/2.34.5/nix-installer.sh | \
   sh -s -- install --no-confirm --extra-conf "trusted-users = ${TARGET_USER}"
 
 # Resolves https://github.com/juspay/nixone/issues/19

--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@ done
 # Check if nix is already installed
 if ! which nix > /dev/null; then
   # Install Nix
-  curl --proto '=https' --tlsv1.2 -sSf -L https://artifacts.nixos.org/nix-installer/tag/2.33.3/nix-installer.sh | \
+  curl --proto '=https' --tlsv1.2 -sSf -L https://artifacts.nixos.org/nix-installer/tag/2.34.5/nix-installer.sh | \
     sh -s -- install --no-confirm --extra-conf "trusted-users = $(whoami)"
 
   # Resolves https://github.com/juspay/nixone/issues/19


### PR DESCRIPTION
The issue (see https://github.com/juspay/nixone/pull/48) that required
pinning to 2.33.3 is fixed in https://github.com/NixOS/nix/pull/15408 (2.34.1)

Also, 2.33.3 and 2.34.1 are vulnerable, see https://discourse.nixos.org/t/nix-security-advisory-privilege-escalation-via-symlink-following-during-fod-output-registration/76900

Hence, on to 2.34.5